### PR TITLE
added contentType for attachment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "abuseio/parser-shadowserver",
     "description": "Parser addon for handling notifications from shadowserver",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "keywords": ["laravel", "abuseio", "parser", "shadowserver"],
     "homepage": "http://abuse.io",
     "type": "library",

--- a/src/Shadowserver.php
+++ b/src/Shadowserver.php
@@ -47,7 +47,9 @@ class Shadowserver extends Parser
 
         foreach ($this->parsedMail->getAttachments() as $attachment) {
             if (strpos($attachment->filename, '.zip') !== false
-                && $attachment->contentType == 'application/octet-stream'
+                && ($attachment->contentType == 'application/octet-stream'
+                        || $attachment->contentType == 'application/zip'
+                )
             ) {
                 $zip = new Zipper;
 


### PR DESCRIPTION
ShadowServer is using a different contentType for attachments for some of their reports. Therefore this extra contentType is added to the code in src/Shadowserver.php. Besides that the version number in composer.json has changed to reflect the change in Shadowserver.php. I was not sure whether this version number needs to be changed though :).