### PR TITLE
New/changed feeds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "abuseio/parser-shadowserver",
     "description": "Parser addon for handling notifications from shadowserver",
-    "version": "3.0.7",
+    "version": "3.0.8",
     "keywords": ["laravel", "abuseio", "parser", "shadowserver"],
     "homepage": "http://abuse.io",
     "type": "library",

--- a/config/Shadowserver.php
+++ b/config/Shadowserver.php
@@ -59,30 +59,27 @@ return [
              ],
          ],
 
-         'sinkhole6' => [
-             'class'     => 'BOTNET_INFECTION',
-             'type'      => 'ABUSE',
-             'enabled'   => true,
-             'fields'    => [
-                 'src_ip',
-                 'src_port',
-                 'dst_ip',
-                 'dst_port',
-                 'timestamp',
-                 'port',
-             ],
-            'aliasses' => [
-                'ip' => 'src_ip',
+        'event6_sinkhole_http' => [
+            'class'     => 'BOTNET_INFECTION',
+            'type'      => 'ABUSE',
+            'enabled'   => true,
+            'fields'    => [
+                'src_ip',
+                'timestamp',
+                'device_type',
+                'http_url',
+                'http_agent',
+                'src_port',
+                'dst_ip',
+                'dst_port',
             ],
-             'filters'   => [
-                 'asn',
-                 'geo',
-                 'region',
-                 'city',
-                 'naics',
-                 'sic',
-             ],
-         ],
+            'filters'   => [
+                'src_asn',
+                'src_geo',
+                'src_region',
+                'src_city',
+            ],
+        ],
 
          'scan_vnc' => [
              'class'     => 'OPEN_VNC_SERVER',
@@ -143,6 +140,26 @@ return [
          ],
  
          'scan_telnet' => [
+             'class'     => 'OPEN_TELNET_SERVER',
+             'type'      => 'INFO',
+             'enabled'   => true,
+             'fields'    => [
+                 'ip',
+                 'timestamp',
+                 'protocol',
+                 'port',
+             ],
+             'filters'   => [
+                 'asn',
+                 'geo',
+                 'region',
+                 'city',
+                 'naics',
+                 'sic',
+             ],
+         ],
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-telnet-report/
+         'scan6_telnet' => [
              'class'     => 'OPEN_TELNET_SERVER',
              'type'      => 'INFO',
              'enabled'   => true,
@@ -409,6 +426,29 @@ return [
                 'city',
             ],
         ],
+        // https://www.shadowserver.org/what-we-do/network-reporting/ssl-poodle-report/
+        'scan6_ssl_poodle' => [
+            'class'     => 'SSLV3_VULNERABLE_SERVER',
+            'type'      => 'INFO',
+            'enabled'   => true,
+            'fields'    => [
+                'ip',
+                'timestamp',
+                'port',
+                'handshake',
+                'cipher_suite',
+                'subject_common_name',
+                'issuer_common_name',
+                'cert_expiration_date',
+                'issuer_organization_name',
+            ],
+            'filters'   => [
+                'asn',
+                'geo',
+                'region',
+                'city',
+            ],
+        ],
 
         'ssl_scan' => [
             'class'     => 'SSLV3_VULNERABLE_SERVER',
@@ -535,26 +575,26 @@ return [
                 'city',
             ],
         ],
-
-        'sinkhole_http_drone' => [
+        // https://www.shadowserver.org/what-we-do/network-reporting/sinkhole-http-events-report/
+        'event4_sinkhole_http' => [
             'class'     => 'BOTNET_INFECTION',
             'type'      => 'ABUSE',
             'enabled'   => true,
             'fields'    => [
-                'ip',
+                'src_ip',
                 'timestamp',
-                'type',
-                'url',
+                'device_type',
+                'http_url',
                 'http_agent',
                 'src_port',
                 'dst_ip',
                 'dst_port',
             ],
             'filters'   => [
-                'asn',
-                'geo',
-                'region',
-                'city',
+                'src_asn',
+                'src_geo',
+                'src_region',
+                'src_city',
             ],
         ],
 
@@ -1067,23 +1107,23 @@ return [
             ],
         ],
         //https://www.shadowserver.org/what-we-do/network-reporting/amplification-ddos-victim-report/
-        'ddos_amplification' => [
+        'event4_honeypot_ddos_amp' => [
             'class'     => 'AMPLICATION_DDOS_VICTIM',
             'type'      => 'INFO',
             'enabled'   => true,
             'fields'    => [
                 'timestamp',
-                'ip',
+                'dst_ip',
                 'protocol',
                 'dst_port',
+                'dst_hostname',
             ],
             'filters'   => [
-                'asn',
-                'geo',
-                'region',
-                'city',
-                'naics',
-                'sic',
+                'dst_asn',
+                'dst_geo',
+                'dst_region',
+                'dst_city',
+                'dst_naics',
             ],
         ],
         
@@ -1361,5 +1401,89 @@ return [
                 'sic',
             ],
         ],      
+        // https://www.shadowserver.org/what-we-do/network-reporting/blocklist-report/
+        'blocklist' => [
+            'class'     => 'RBL',
+            'type'      => 'INFO',
+            'enabled'   => true,
+            'fields'    => [
+                'ip',
+                'timestamp',
+                'source',
+            ],
+            'filters'   => [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+                'sic',
+            ],
+        ],
+        // https://www.shadowserver.org/what-we-do/network-reporting/vulnerable-smtp-report/
+       'scan_smtp_vulnerable' => [
+            'class'     => 'VULNERABLE_SMTP_SERVER',
+            'type'      => 'INFO',
+            'enabled'   => true,
+            'fields'    => [
+                'ip',
+                'timestamp',
+                'port',
+                'tag',
+                'sector',
+                'banner',
+            ],
+            'filters'   => [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+                'sic',
+            ],
+        ],
+        // https://www.shadowserver.org/what-we-do/network-reporting/vulnerable-smtp-report/
+        'scan6_smtp_vulnerable' => [
+            'class'     => 'VULNERABLE_SMTP_SERVER',
+            'type'      => 'INFO',
+            'enabled'   => true,
+            'fields'    => [
+                'ip',
+                'timestamp',
+                'port',
+                'tag',
+                'sector',
+                'banner',
+            ],
+            'filters'   => [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+                'sic',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-amqp-report/
+        'scan_amqp' => [
+            'class'     => 'OPEN_AMQP',
+            'type'      => 'INFO',
+            'enabled'   =>  true,
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>[
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
     ],
 ];

--- a/config/Shadowserver.php
+++ b/config/Shadowserver.php
@@ -1681,7 +1681,7 @@ return [
         'scan6_ssh' => [
             'class'     => 'OPEN_SSH_SERVER',
             'type'      => 'INFO',
-            'enabled'   => 'true',
+            'enabled'   =>  true,
             'fields'    =>  [
                 'timestamp',
                 'ip',
@@ -1702,7 +1702,7 @@ return [
         'scan_smtp' => [
             'class'     => 'OPEN_SMTP_SERVER',
             'type'      => 'INFO',
-            'enabled'   => 'true',
+            'enabled'   =>  true,
             'fields'    =>  [
                 'timestamp',
                 'ip',
@@ -1723,7 +1723,7 @@ return [
         'scan6_smtp' => [
             'class'     => 'OPEN_SMTP_SERVER',
             'type'      => 'INFO',
-            'enabled'   => 'true',
+            'enabled'   =>  true,
             'fields'    =>  [
                 'timestamp',
                 'ip',
@@ -1744,7 +1744,7 @@ return [
         'scan_stun' =>  [
             'class'     => 'OPEN_STUN_SERVICE',
             'type'      => 'INFO',
-            'enabled'   => 'true',
+            'enabled'   =>  true,
             'fields'    =>  [
                 'timestamp',
                 'ip',
@@ -1765,7 +1765,7 @@ return [
         'scan6_stun' =>  [
             'class'     => 'OPEN_STUN_SERVICE',
             'type'      => 'INFO',
-            'enabled'   => 'true',
+            'enabled'   =>  true,
             'fields'    =>  [
                 'timestamp',
                 'ip',
@@ -1786,7 +1786,7 @@ return [
         'scan_socks' => [
             'class'     => 'OPEN_SOCKS_PROXY',
             'type'      => 'INFO',
-            'enabled'   => 'true',
+            'enabled'   =>  true,
             'fields'    =>  [
                 'timestamp',
                 'ip',
@@ -1807,7 +1807,7 @@ return [
         'scan_ics' => [
             'class'     => 'OPEN_ICS',
             'type'      => 'INFO',
-            'enabled'   => 'true',
+            'enabled'   =>  true,
             'fields'    =>  [
                 'timestamp',
                 'ip',
@@ -1833,7 +1833,7 @@ return [
         'scan_postgres' => [
             'class'     => 'OPEN_POSTGRESQL_SERVER',
             'type'      => 'INFO',
-            'enabled'   => 'true',
+            'enabled'   =>  true,
             'fields'    =>  [
                 'timestamp',
                 'ip',
@@ -1854,7 +1854,7 @@ return [
         'scan6_postgres' => [
             'class'     => 'OPEN_POSTGRESQL_SERVER',
             'type'      => 'INFO',
-            'enabled'   => 'true',
+            'enabled'   =>  true,
             'fields'    =>  [
                 'timestamp',
                 'ip',
@@ -1875,7 +1875,7 @@ return [
         'scan_epmd' => [
             'class'     => 'OPEN_ERLANG_PORTMAPPER_DAEMON',
             'type'      => 'INFO',
-            'enabled'   => 'true',
+            'enabled'   =>  true,
             'fields'    =>  [
                 'timestamp',
                 'ip',
@@ -1897,7 +1897,7 @@ return [
         'device_id' => [
             'class'     => 'DEVICE_IDENTIFICATION',
             'type'      => 'INFO',
-            'enabled'   => 'false',
+            'enabled'   =>  false,
             'fields'    =>  [
                 'timestamp',
                 'ip',
@@ -1920,7 +1920,7 @@ return [
         'device_id6' => [
             'class'     => 'DEVICE_IDENTIFICATION',
             'type'      => 'INFO',
-            'enabled'   => 'false',
+            'enabled'   =>  false,
             'fields'    =>  [
                 'timestamp',
                 'ip',

--- a/config/Shadowserver.php
+++ b/config/Shadowserver.php
@@ -119,6 +119,25 @@ return [
              ],
          ],
 
+         'scan6_smb' => [
+             'class'     => 'OPEN_SMB_SERVER',
+             'type'      => 'INFO',
+             'enabled'   => true,
+             'fields'    => [
+                 'ip',
+                 'timestamp',
+                 'port',
+             ],
+             'filters'   => [
+                 'asn',
+                 'geo',
+                 'region',
+                 'city',
+                 'naics',
+                 'sic',
+             ],
+         ],
+
          'scan_cwmp' => [
              'class'     => 'OPEN_CWMP_SERVER',
              'type'      => 'INFO',
@@ -257,6 +276,27 @@ return [
                 'sector',
             ],
         ],
+
+        'scan6_rdp' => [
+            'class'     => 'OPEN_RDP_SERVER',
+            'type'      => 'INFO',
+            'enabled'   => true,
+            'fields'    => [
+                'ip',
+                'timestamp',
+                'port',
+            ],
+            'filters'   => [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+                'sic',
+                'sector',
+            ],
+        ],
+
 
         'scan_tftp' => [
             'class'     => 'OPEN_TFTP_SERVER',
@@ -689,6 +729,30 @@ return [
             ],
         ],
 
+        'scan6_ntp' => [
+            'class'     => 'OPEN_NTP_SERVER',
+            'type'      => 'INFO',
+            'enabled'   => true,
+            'fields'    => [
+                'ip',
+                'timestamp',
+                'clock',
+                'error',
+                'frequency',
+                'peer',
+                'refid',
+                'reftime',
+                'stratum',
+                'system',
+            ],
+            'filters'   => [
+                'asn',
+                'geo',
+                'region',
+                'city',
+            ],
+        ],
+
         'scan_snmp' => [
             'class'     => 'OPEN_SNMP_SERVER',
             'type'      => 'INFO',
@@ -988,6 +1052,27 @@ return [
              ],
         ],
 
+        'scan6_ftp' => [
+             'class'     => 'OPEN_FTP_SERVER',
+             'type'      => 'INFO',
+             'enabled'   => true,
+             'fields'    => [
+                 'ip',
+                 'timestamp',
+                 'port',
+                 'hostname',
+                 'banner',
+             ],
+             'filters'   => [
+                 'asn',
+                 'geo',
+                 'region',
+                 'city',
+                 'naics',
+                 'sic',
+             ],
+        ],
+
         'scan_http' => [
              'class'     => 'OPEN_HTTP_SERVER',
              'type'      => 'INFO',
@@ -1007,6 +1092,28 @@ return [
                  'sic',
              ],
         ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-http-report/
+        'scan6_http' =>  [
+            'class'     => 'OPEN_HTTP_SERVER',
+            'type'      => 'INFO',
+            'enabled'   => 'true',
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
 
         'scan_rsync' => [
              'class'     => 'OPEN_RSYNC_SERVER',
@@ -1301,6 +1408,27 @@ return [
                 'naics',
             ],
         ],
+
+        //https://www.shadowserver.org/what-we-do/network-reporting/open-mqtt-report/
+        'scan6_mqtt' => [
+            'class'     => 'OPEN_MQTT',
+            'type'      => 'INFO',
+            'enabled'   =>  true,
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>[
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
         //https://www.shadowserver.org/what-we-do/network-reporting/accessible-coap-report/
         'scan_coap' => [
             'class'     => 'OPEN_COAP',
@@ -1403,6 +1531,27 @@ return [
                 'sic',
             ],
         ],
+
+        'scan6_http_vulnerable' => [
+            'class'     => 'OPEN_BASIC_AUTH_SERVICE',
+            'type'      => 'INFO',
+            'enabled'   => true,
+            'fields'    => [
+                'ip',
+                'timestamp',
+                'protocol',
+                'port',
+            ],
+            'filters'   => [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+                'sic',
+            ],
+        ],
+
         //https://www.shadowserver.org/what-we-do/network-reporting/darknet-report/
         'darknet' => [
             'class'     => 'DARKNET',
@@ -1424,7 +1573,7 @@ return [
         ],      
         // https://www.shadowserver.org/what-we-do/network-reporting/blocklist-report/
         'blocklist' => [
-            'class'     => 'RBL',
+            'class'     => 'RBL_LISTED',
             'type'      => 'INFO',
             'enabled'   => true,
             'fields'    => [
@@ -1498,7 +1647,291 @@ return [
                 'protocol',
                 'port',
             ],
-            'filters'   =>[
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-ssh-report/
+        'scan_ssh' => [
+            'class'     => 'OPEN_SSH_SERVER',
+            'type'      => 'INFO',
+            'enabled'   => 'true',
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-ssh-report/
+        'scan6_ssh' => [
+            'class'     => 'OPEN_SSH_SERVER',
+            'type'      => 'INFO',
+            'enabled'   => 'true',
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-smtp-report/
+        'scan_smtp' => [
+            'class'     => 'OPEN_SMTP_SERVER',
+            'type'      => 'INFO',
+            'enabled'   => 'true',
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-smtp-report/
+        'scan6_smtp' => [
+            'class'     => 'OPEN_SMTP_SERVER',
+            'type'      => 'INFO',
+            'enabled'   => 'true',
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-stun-service-report/
+        'scan_stun' =>  [
+            'class'     => 'OPEN_STUN_SERVICE',
+            'type'      => 'INFO',
+            'enabled'   => 'true',
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-stun-service-report/
+        'scan6_stun' =>  [
+            'class'     => 'OPEN_STUN_SERVICE',
+            'type'      => 'INFO',
+            'enabled'   => 'true',
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-socks4-5-proxy-report/
+        'scan_socks' => [
+            'class'     => 'OPEN_SOCKS_PROXY',
+            'type'      => 'INFO',
+            'enabled'   => 'true',
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-ics-report/
+        'scan_ics' => [
+            'class'     => 'OPEN_ICS',
+            'type'      => 'INFO',
+            'enabled'   => 'true',
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+                'device_vendor',
+                'device_type',
+                'device_model',
+                'device_version',
+                'device_id',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-postgresql-server-report/
+        'scan_postgres' => [
+            'class'     => 'OPEN_POSTGRESQL_SERVER',
+            'type'      => 'INFO',
+            'enabled'   => 'true',
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-postgresql-server-report/
+        'scan6_postgres' => [
+            'class'     => 'OPEN_POSTGRESQL_SERVER',
+            'type'      => 'INFO',
+            'enabled'   => 'true',
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-erlang-port-mapper-report-daemon/
+        'scan_epmd' => [
+            'class'     => 'OPEN_ERLANG_PORTMAPPER_DAEMON',
+            'type'      => 'INFO',
+            'enabled'   => 'true',
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+                'nodes',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/device-identification-report/
+        'device_id' => [
+            'class'     => 'DEVICE_IDENTIFICATION',
+            'type'      => 'INFO',
+            'enabled'   => 'false',
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+                'device_vendor',
+                'device_type',
+                'device_model',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        'device_id6' => [
+            'class'     => 'DEVICE_IDENTIFICATION',
+            'type'      => 'INFO',
+            'enabled'   => 'false',
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+                'device_vendor',
+                'device_type',
+                'device_model',
+            ],
+            'filters'   =>  [
                 'asn',
                 'geo',
                 'region',

--- a/config/Shadowserver.php
+++ b/config/Shadowserver.php
@@ -832,7 +832,7 @@ return [
         ],
 
         'scan_ipmi' => [
-            'class'     => 'OPEN_IPMI_SERVER',
+            'class'     => 'OPEN_IMPI_SERVER',
             'type'      => 'INFO',
             'enabled'   => true,
             'fields'    => [

--- a/config/Shadowserver.php
+++ b/config/Shadowserver.php
@@ -1106,7 +1106,7 @@ return [
                 'sic',
             ],
         ],
-        //https://www.shadowserver.org/what-we-do/network-reporting/amplification-ddos-victim-report/
+        // https://www.shadowserver.org/what-we-do/network-reporting/honeypot-amplification-ddos-events-report/
         'event4_honeypot_ddos_amp' => [
             'class'     => 'AMPLICATION_DDOS_VICTIM',
             'type'      => 'INFO',
@@ -1126,6 +1126,27 @@ return [
                 'dst_naics',
             ],
         ],
+        // https://www.shadowserver.org/what-we-do/network-reporting/honeypot-amplification-ddos-events-report/
+        'event6_honeypot_ddos_amp' => [
+            'class'     => 'AMPLICATION_DDOS_VICTIM',
+            'type'      => 'INFO',
+            'enabled'   => true,
+            'fields'    => [
+                'timestamp',
+                'dst_ip',
+                'protocol',
+                'dst_port',
+                'dst_hostname',
+            ],
+            'filters'   => [
+                'dst_asn',
+                'dst_geo',
+                'dst_region',
+                'dst_city',
+                'dst_naics',
+            ],
+        ],
+
         
         //https://www.shadowserver.org/what-we-do/network-reporting/accessible-adb-report/
         'scan_adb' => [

--- a/config/Shadowserver.php
+++ b/config/Shadowserver.php
@@ -832,7 +832,7 @@ return [
         ],
 
         'scan_ipmi' => [
-            'class'     => 'OPEN_IMPI_SERVER',
+            'class'     => 'OPEN_IPMI_SERVER',
             'type'      => 'INFO',
             'enabled'   => true,
             'fields'    => [


### PR DESCRIPTION
This commit adds the following feeds:

- [scan6_ssl_poodle](https://www.shadowserver.org/what-we-do/network-reporting/ssl-poodle-report/);
- [blocklist](https://www.shadowserver.org/what-we-do/network-reporting/blocklist-report/);
- [scan_smtp_vulnerable](https://www.shadowserver.org/what-we-do/network-reporting/vulnerable-smtp-report/);
- [scan6_smtp_vulnerable](https://www.shadowserver.org/what-we-do/network-reporting/vulnerable-smtp-report/);
- [scan6_telnet](https://www.shadowserver.org/what-we-do/network-reporting/accessible-telnet-report/);
- [scan_amqp](https://www.shadowserver.org/what-we-do/network-reporting/accessible-amqp-report/);
- [event6_honeypot_ddos_amp](https://www.shadowserver.org/what-we-do/network-reporting/honeypot-amplification-ddos-events-report/).

I also changed the following feeds since they where discontinued by Shadowserver. I've changed them with the "new" feeds from Shadowserver:

- [sinkhole_http_drone](https://www.shadowserver.org/what-we-do/network-reporting/sinkhole-http-drone-report/) became [event4_sinkhole_http](https://www.shadowserver.org/what-we-do/network-reporting/sinkhole-http-events-report/);
- [sinkhole6](https://www.shadowserver.org/what-we-do/network-reporting/sinkhole6-http-drone-report/) became [event6_sinkhole_http](https://www.shadowserver.org/what-we-do/network-reporting/sinkhole-http-events-report/);
- [ddos_amplification](https://www.shadowserver.org/what-we-do/network-reporting/amplification-ddos-victim-report/) became [event4_honeypot_ddos_amp](https://www.shadowserver.org/what-we-do/network-reporting/honeypot-amplification-ddos-events-report/).

If you want me to change some fields/feeds/filters, lemme know!