### PR TITLE
rename response_length to response_size

### DIFF
--- a/config/Shadowserver.php
+++ b/config/Shadowserver.php
@@ -433,7 +433,7 @@ return [
                 'instance_name',
                 'tcp_port',
                 'named_pipe',
-                'response_length',
+                'response_size',
                 'amplification',
             ],
             'filters'   => [


### PR DESCRIPTION
The docs https://www.shadowserver.org/what-we-do/network-reporting/open-ms-sql-server-resolution-service-report/ state
that there's a field called `response_length`, however in de sample at the bottom of the page and in the csv report we received the field is named `response_size`.