### PR TITLE
Add more feeds to parser

### DIFF
--- a/config/Shadowserver.php
+++ b/config/Shadowserver.php
@@ -1038,7 +1038,7 @@ return [
         ],
 
         // https://www.shadowserver.org/what-we-do/network-reporting/open-nat-pmp-report/
-        'scan_net_pmp' => [
+        'scan_nat_pmp' => [
             'class'     => 'OPEN_NATPMP_SERVER',
             'type'      => 'INFO',
             'enabled'   => true,

--- a/config/Shadowserver.php
+++ b/config/Shadowserver.php
@@ -15,6 +15,7 @@ return [
 
 
     'feeds' => [
+    
          'cisco_smart_install' => [
              'class'     => 'OPEN_SMARTINSTALL',
              'type'      => 'INFO',
@@ -34,6 +35,27 @@ return [
              ],
          ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-cisco-smart-install-report/
+        'scan_cisco_smart_install' => [
+             'class'     => 'OPEN_SMARTINSTALL',
+             'type'      => 'INFO',
+             'enabled'   => true,
+             'fields'    => [
+                 'ip',
+                 'timestamp',
+                 'port',
+             ],
+             'filters'   => [
+                 'asn',
+                 'geo',
+                 'region',
+                 'city',
+                 'naics',
+                 'sic',
+             ],
+         ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-hadoop-report/
          'scan_hadoop' => [
              'class'     => 'OPEN_HADOOP_SERVER',
              'type'      => 'INFO',
@@ -59,6 +81,7 @@ return [
              ],
          ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/sinkhole-http-events-report/
         'event6_sinkhole_http' => [
             'class'     => 'BOTNET_INFECTION',
             'type'      => 'ABUSE',
@@ -81,6 +104,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-vnc-report/
          'scan_vnc' => [
              'class'     => 'OPEN_VNC_SERVER',
              'type'      => 'INFO',
@@ -100,6 +124,27 @@ return [
              ],
          ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-vnc-report/
+         'scan6_vnc' => [
+             'class'     => 'OPEN_VNC_SERVER',
+             'type'      => 'INFO',
+             'enabled'   => true,
+             'fields'    => [
+                 'ip',
+                 'timestamp',
+                 'port',
+             ],
+             'filters'   => [
+                 'asn',
+                 'geo',
+                 'region',
+                 'city',
+                 'naics',
+                 'sic',
+             ],
+         ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-smb-report/
          'scan_smb' => [
              'class'     => 'OPEN_SMB_SERVER',
              'type'      => 'INFO',
@@ -119,6 +164,7 @@ return [
              ],
          ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-smb-report/
          'scan6_smb' => [
              'class'     => 'OPEN_SMB_SERVER',
              'type'      => 'INFO',
@@ -138,6 +184,7 @@ return [
              ],
          ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-cwmp-report/
          'scan_cwmp' => [
              'class'     => 'OPEN_CWMP_SERVER',
              'type'      => 'INFO',
@@ -157,7 +204,29 @@ return [
                  'sic',
              ],
          ],
- 
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-cwmp-report/
+         'scan6_cwmp' => [
+             'class'     => 'OPEN_CWMP_SERVER',
+             'type'      => 'INFO',
+             'enabled'   => true,
+             'fields'    => [
+                 'ip',
+                 'timestamp',
+                 'protocol',
+                 'port',
+             ],
+             'filters'   => [
+                 'asn',
+                 'geo',
+                 'region',
+                 'city',
+                 'naics',
+                 'sic',
+             ],
+         ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-telnet-report/
          'scan_telnet' => [
              'class'     => 'OPEN_TELNET_SERVER',
              'type'      => 'INFO',
@@ -177,6 +246,7 @@ return [
                  'sic',
              ],
          ],
+    
         // https://www.shadowserver.org/what-we-do/network-reporting/accessible-telnet-report/
          'scan6_telnet' => [
              'class'     => 'OPEN_TELNET_SERVER',
@@ -237,6 +307,7 @@ return [
              ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/vulnerable-isakmp-report/
         'scan_isakmp' => [
             'class'     => 'ISAKMP_VULNERABLE_DEVICE',
             'type'      => 'INFO',
@@ -257,6 +328,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-rdp-report/
         'scan_rdp' => [
             'class'     => 'OPEN_RDP_SERVER',
             'type'      => 'INFO',
@@ -277,6 +349,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-rdp-report/
         'scan6_rdp' => [
             'class'     => 'OPEN_RDP_SERVER',
             'type'      => 'INFO',
@@ -297,7 +370,7 @@ return [
             ],
         ],
 
-
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-accessible-tftp-report/
         'scan_tftp' => [
             'class'     => 'OPEN_TFTP_SERVER',
             'type'      => 'INFO',
@@ -318,6 +391,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-mdns-report/
         'scan_mdns' => [
             'class'     => 'OPEN_MDNS_SERVICE',
             'type'      => 'INFO',
@@ -339,6 +413,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-portmapper-report/
         'scan_portmapper' => [
             'class'     => 'OPEN_PORTMAP_SERVER',
             'type'      => 'INFO',
@@ -363,6 +438,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-elasticsearch-report/
         'scan_elasticsearch' => [
             'class'     => 'OPEN_ELASTICSEARCH_SERVER',
             'type'      => 'INFO',
@@ -383,7 +459,30 @@ return [
                 'city',
             ],
         ],
+    
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-elasticsearch-report/
+        'scan6_elasticsearch' => [
+            'class'     => 'OPEN_ELASTICSEARCH_SERVER',
+            'type'      => 'INFO',
+            'enabled'   => true,
+            'fields'    => [
+                'ip',
+                'timestamp',
+                'protocol',
+                'port',
+                'version',
+                'name',
+                'cluster_name',
+            ],
+            'filters'   => [
+                'asn',
+                'geo',
+                'region',
+                'city',
+            ],
+        ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-qotd-report/
         'scan_qotd' => [
             'class'     => 'OPEN_QOTD_SERVER',
             'type'      => 'INFO',
@@ -420,6 +519,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-ms-sql-server-resolution-service-report/
         'scan_mssql' => [
             'class'     => 'OPEN_MSSQL_SERVER',
             'type'      => 'INFO',
@@ -444,6 +544,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/ssl-poodle-report/
         'scan_ssl_poodle' => [
             'class'     => 'SSLV3_VULNERABLE_SERVER',
             'type'      => 'INFO',
@@ -466,6 +567,7 @@ return [
                 'city',
             ],
         ],
+    
         // https://www.shadowserver.org/what-we-do/network-reporting/ssl-poodle-report/
         'scan6_ssl_poodle' => [
             'class'     => 'SSLV3_VULNERABLE_SERVER',
@@ -513,7 +615,32 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/ssl-freak-report/
         'scan_ssl_freak' => [
+            'class'     => 'FREAK_VULNERABLE_SERVER',
+            'type'      => 'INFO',
+            'enabled'   => true,
+            'fields'    => [
+                'ip',
+                'timestamp',
+                'port',
+                'handshake',
+                'cipher_suite',
+                'freak_cipher_suite',
+                'subject_common_name',
+                'issuer_common_name',
+                'cert_expiration_date',
+            ],
+            'filters'   => [
+                'asn',
+                'geo',
+                'region',
+                'city',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/ssl-freak-report/
+        'scan6_ssl_freak' => [
             'class'     => 'FREAK_VULNERABLE_SERVER',
             'type'      => 'INFO',
             'enabled'   => true,
@@ -554,7 +681,30 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/ntp-monitor-report/
         'scan_ntpmonitor' => [
+            'class'     => 'POSSIBLE_DDOS_SENDING_SERVER',
+            'type'      => 'ABUSE',
+            'enabled'   => true,
+            'fields'    => [
+                'ip',
+                'timestamp',
+                'protocol',
+                'port',
+                'hostname',
+                'packets',
+                'size',
+            ],
+            'filters'   => [
+                'asn',
+                'geo',
+                'region',
+                'city',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/ntp-monitor-report/
+        'scan6_ntpmonitor' => [
             'class'     => 'POSSIBLE_DDOS_SENDING_SERVER',
             'type'      => 'ABUSE',
             'enabled'   => true,
@@ -615,6 +765,7 @@ return [
                 'city',
             ],
         ],
+    
         // https://www.shadowserver.org/what-we-do/network-reporting/sinkhole-http-events-report/
         'event4_sinkhole_http' => [
             'class'     => 'BOTNET_INFECTION',
@@ -705,6 +856,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/ntp-version-report/
         'scan_ntp' => [
             'class'     => 'OPEN_NTP_SERVER',
             'type'      => 'INFO',
@@ -729,6 +881,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/ntp-version-report/
         'scan6_ntp' => [
             'class'     => 'OPEN_NTP_SERVER',
             'type'      => 'INFO',
@@ -753,6 +906,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-snmp-report/
         'scan_snmp' => [
             'class'     => 'OPEN_SNMP_SERVER',
             'type'      => 'INFO',
@@ -772,6 +926,27 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-snmp-report/
+        'scan6_snmp' => [
+            'class'     => 'OPEN_SNMP_SERVER',
+            'type'      => 'INFO',
+            'enabled'   => true,
+            'fields'    => [
+                'ip',
+                'timestamp',
+                'sysdesc',
+                'sysname',
+                'version',
+            ],
+            'filters'   => [
+                'asn',
+                'geo',
+                'region',
+                'city',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-netbios-report/
         'scan_netbios' => [
             'class'     => 'OPEN_NETBIOS_SERVER',
             'type'      => 'INFO',
@@ -812,6 +987,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-chargen-report/
         'scan_chargen' => [
             'class'     => 'OPEN_CHARGEN_SERVER',
             'type'      => 'INFO',
@@ -831,6 +1007,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-ipmi-report/
         'scan_ipmi' => [
             'class'     => 'OPEN_IMPI_SERVER',
             'type'      => 'INFO',
@@ -860,6 +1037,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-nat-pmp-report/
         'scan_net_pmp' => [
             'class'     => 'OPEN_NATPMP_SERVER',
             'type'      => 'INFO',
@@ -880,26 +1058,7 @@ return [
             ],
         ],
 
-        'scan_nat_pmp' => [
-            'class'     => 'OPEN_NATPMP_SERVER',
-            'type'      => 'INFO',
-            'enabled'   => true,
-            'fields'    => [
-                'ip',
-                'timestamp',
-                'protocol',
-                'port',
-                'version',
-                'uptime',
-            ],
-            'filters'   => [
-                'asn',
-                'geo',
-                'region',
-                'city',
-            ],
-        ],
-
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-redis-report/
         'scan_redis' => [
             'class'     => 'OPEN_REDIS_SERVER',
             'type'      => 'INFO',
@@ -967,6 +1126,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-mongodb-report/
         'scan_mongodb' => [
             'class'     => 'OPEN_MONGODB_SERVER',
             'type'      => 'INFO',
@@ -987,6 +1147,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-afp-report/
         'scan_afp' => [
             'class'     => 'OPEN_AFP_SERVER',
             'type'      => 'INFO',
@@ -1012,6 +1173,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/dns-open-resolvers-report/
         'scan_dns' => [
             'class'     => 'OPEN_DNS_RESOLVER',
             'type'      => 'INFO',
@@ -1031,6 +1193,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/dns-open-resolvers-report/
         'scan6_dns' => [
             'class'     => 'OPEN_DNS_RESOLVER',
             'type'      => 'INFO',
@@ -1050,6 +1213,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-ftp-report/
         'scan_ftp' => [
              'class'     => 'OPEN_FTP_SERVER',
              'type'      => 'INFO',
@@ -1071,6 +1235,7 @@ return [
              ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-ftp-report/
         'scan6_ftp' => [
              'class'     => 'OPEN_FTP_SERVER',
              'type'      => 'INFO',
@@ -1092,6 +1257,7 @@ return [
              ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-http-report/
         'scan_http' => [
              'class'     => 'OPEN_HTTP_SERVER',
              'type'      => 'INFO',
@@ -1133,7 +1299,7 @@ return [
             ],
         ],
 
-
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-rsync-report/
         'scan_rsync' => [
              'class'     => 'OPEN_RSYNC_SERVER',
              'type'      => 'INFO',
@@ -1154,6 +1320,28 @@ return [
              ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-rsync-report/
+        'scan6_rsync' => [
+             'class'     => 'OPEN_RSYNC_SERVER',
+             'type'      => 'INFO',
+             'enabled'   => true,
+             'fields'    => [
+                 'ip',
+                 'timestamp',
+                 'port',
+                 'hostname',
+             ],
+             'filters'   => [
+                 'asn',
+                 'geo',
+                 'region',
+                 'city',
+                 'naics',
+                 'sic',
+             ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-ldap-tcp-report/
         'scan_ldap_tcp' => [
              'class'     => 'OPEN_LDAP_SERVER',
              'type'      => 'INFO',
@@ -1173,6 +1361,28 @@ return [
                  'sic',
              ],
         ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-ldap-tcp-report/
+        'scan6_ldap_tcp' => [
+             'class'     => 'OPEN_LDAP_SERVER',
+             'type'      => 'INFO',
+             'enabled'   => true,
+             'fields'    => [
+                 'ip',
+                 'timestamp',
+                 'protocol',
+                 'port',
+             ],
+             'filters'   => [
+                 'asn',
+                 'geo',
+                 'region',
+                 'city',
+                 'naics',
+                 'sic',
+             ],
+        ],
+    
         // https://www.shadowserver.org/what-we-do/network-reporting/open-ldap-report/
         'scan_ldap_udp' => [
              'class'     => 'OPEN_LDAP_SERVER',
@@ -1193,7 +1403,6 @@ return [
                  'sic',
              ],
          ],
-
         
         //https://www.shadowserver.org/what-we-do/network-reporting/open-proxy-report/
         'scan_open_proxy_report' => [
@@ -1234,6 +1443,7 @@ return [
                 'sic',
             ],
         ],
+    
         //https://www.shadowserver.org/what-we-do/network-reporting/brute-force-attack-report/
         'brute_force_attack_report' => [
             'class'     => 'BRUTE_FORCE_ATTACK',
@@ -1253,6 +1463,7 @@ return [
                 'sic',
             ],
         ],
+    
         // https://www.shadowserver.org/what-we-do/network-reporting/honeypot-amplification-ddos-events-report/
         'event4_honeypot_ddos_amp' => [
             'class'     => 'AMPLICATION_DDOS_VICTIM',
@@ -1273,6 +1484,7 @@ return [
                 'dst_naics',
             ],
         ],
+    
         // https://www.shadowserver.org/what-we-do/network-reporting/honeypot-amplification-ddos-events-report/
         'event6_honeypot_ddos_amp' => [
             'class'     => 'AMPLICATION_DDOS_VICTIM',
@@ -1293,7 +1505,6 @@ return [
                 'dst_naics',
             ],
         ],
-
         
         //https://www.shadowserver.org/what-we-do/network-reporting/accessible-adb-report/
         'scan_adb' => [
@@ -1315,6 +1526,7 @@ return [
                 'sic',
             ],
         ],
+    
         //https://www.shadowserver.org/what-we-do/network-reporting/accessible-apple-remote-desktop-ard-report/
         'scan_ard' => [
             'class'     => 'ACCESSIBLE_APPLE_REMOTE_DESKTOP_ARD_REPORT',
@@ -1356,6 +1568,7 @@ return [
                 'sic',
             ],
         ],
+    
         //https://www.shadowserver.org/what-we-do/network-reporting/caida-ip-spoofer-report/
         'caida_ip_spoofer' => [
             'class'     => 'CAIDA_IP_SPOOFER_REPORT',
@@ -1374,6 +1587,7 @@ return [
                 'sic',
             ],
         ],
+    
        //https://www.shadowserver.org/what-we-do/network-reporting/drone-botnet-drone-report/
         'drone_brute_force' => [
             'class'     => 'DRONE_BOTNET_DRONE_REPORT',
@@ -1411,6 +1625,7 @@ return [
                 'city',
             ],
         ],
+    
         //https://www.shadowserver.org/what-we-do/network-reporting/open-db2-discovery-service-report/
         'scan_db2' => [
             'class'     => 'OPEN_DB2_DISCOVERY_SERVICE_REPORT',
@@ -1429,6 +1644,7 @@ return [
                 'city',
             ],
         ],
+    
         //https://www.shadowserver.org/what-we-do/network-reporting/open-mqtt-report/
         'scan_mqtt' => [
             'class'     => 'OPEN_MQTT',
@@ -1490,6 +1706,7 @@ return [
                 'response',
             ],
         ],
+    
         //https://www.shadowserver.org/what-we-do/network-reporting/open-ipp-report/
         'scan_ipp' => [
             'class'     => 'OPEN_IPP',
@@ -1511,6 +1728,7 @@ return [
                 'response',
             ],
         ],
+    
         //https://www.shadowserver.org/what-we-do/network-reporting/accessible-radmin-report/
         'scan_radmin' => [
             'class'     => 'OPEN_RADMIN',
@@ -1531,6 +1749,7 @@ return [
                 'sic',
             ],
         ],
+    
         //https://www.shadowserver.org/what-we-do/network-reporting/accessible-ms-rdpeudp/
         'scan_rdpeudp' => [
             'class'     => 'OPEN_RDPEUDP',
@@ -1551,6 +1770,7 @@ return [
                 'sic',
             ],
         ],
+    
         //https://www.shadowserver.org/what-we-do/network-reporting/vulnerable-http-report/
         'scan_http_vulnerable' => [
             'class'     => 'OPEN_BASIC_AUTH_SERVICE',
@@ -1572,6 +1792,7 @@ return [
             ],
         ],
 
+        //https://www.shadowserver.org/what-we-do/network-reporting/vulnerable-http-report/
         'scan6_http_vulnerable' => [
             'class'     => 'OPEN_BASIC_AUTH_SERVICE',
             'type'      => 'INFO',
@@ -1610,7 +1831,8 @@ return [
                 'naics',
                 'sic',
             ],
-        ],      
+        ], 
+    
         // https://www.shadowserver.org/what-we-do/network-reporting/blocklist-report/
         'blocklist' => [
             'class'     => 'RBL_LISTED',
@@ -1630,6 +1852,7 @@ return [
                 'sic',
             ],
         ],
+    
         // https://www.shadowserver.org/what-we-do/network-reporting/vulnerable-smtp-report/
        'scan_smtp_vulnerable' => [
             'class'     => 'VULNERABLE_SMTP_SERVER',
@@ -1651,6 +1874,7 @@ return [
                 'sic',
             ],
         ],
+    
         // https://www.shadowserver.org/what-we-do/network-reporting/vulnerable-smtp-report/
         'scan6_smtp_vulnerable' => [
             'class'     => 'VULNERABLE_SMTP_SERVER',
@@ -1955,6 +2179,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/device-identification-report/
         'device_id6' => [
             'class'     => 'DEVICE_IDENTIFICATION',
             'type'      => 'INFO',
@@ -2021,6 +2246,7 @@ return [
                 'naics',
             ],
         ],
+    
         // https://www.shadowserver.org/what-we-do/network-reporting/accessible-msmq-service-report/
         'population_msmq' => [
             'class'     => 'ACCESSIBLE_MSMQ_SERVICE',
@@ -2041,6 +2267,7 @@ return [
                 'naics',
             ],
         ],
+    
         // https://www.shadowserver.org/what-we-do/network-reporting/accessible-msmq-service-report/
         'population6_msmq' => [
             'class'     => 'ACCESSIBLE_MSMQ_SERVICE',
@@ -2061,6 +2288,7 @@ return [
                 'naics',
             ],
         ],
+    
         // https://www.shadowserver.org/what-we-do/network-reporting/accessible-slp-service-report/
         'scan_slp' => [
             'class'     => 'ACCESSIBLE_SLP_SERVICE',
@@ -2082,6 +2310,7 @@ return [
                 'naics',
             ],
         ],
+    
         // https://www.shadowserver.org/what-we-do/network-reporting/accessible-slp-service-report/
         'scan6_slp' => [
             'class'     => 'ACCESSIBLE_SLP_SERVICE',
@@ -2103,6 +2332,7 @@ return [
                 'naics',
             ],
         ],
+    
         // https://www.shadowserver.org/what-we-do/network-reporting/accessible-bgp-service-report/
         'population_bgp' => [
             'class'     => 'ACCESSIBLE_BGP_SERVICE',
@@ -2124,6 +2354,7 @@ return [
                 'naics',
             ],
         ],
+    
         // https://www.shadowserver.org/what-we-do/network-reporting/accessible-bgp-service-report/
         'population6_bgp' => [
             'class'     => 'ACCESSIBLE_BGP_SERVICE',
@@ -2171,7 +2402,7 @@ return [
             ],
         ],
     
-    // https://www.shadowserver.org/what-we-do/network-reporting/accessible-mysql-server-report/
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-mysql-server-report/
         'scan_mysql' => [
             'class'     => 'OPEN_MYSQL_SERVER',
             'type'      => 'INFO',

--- a/config/Shadowserver.php
+++ b/config/Shadowserver.php
@@ -2170,6 +2170,49 @@ return [
                 'src_ip' => 'ip',
             ],
         ],
+    
+    // https://www.shadowserver.org/what-we-do/network-reporting/accessible-mysql-server-report/
+        'scan_mysql' => [
+            'class'     => 'OPEN_MYSQL_SERVER',
+            'type'      => 'INFO',
+            'enabled'   =>  true,
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        // https://www.shadowserver.org/what-we-do/network-reporting/accessible-mysql-server-report/
+        'scan6_mysql' => [
+            'class'     => 'OPEN_MYSQL_SERVER',
+            'type'      => 'INFO',
+            'enabled'   =>  true,
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
 
     ],
 ];


### PR DESCRIPTION
* Added the following ipv6 variations of pre-existing feeds: scan6_vnc, scan6_cwmp, scan6_elasticsearch, scan6_ssl_freak, scan6_ntpmonitor, scan6_snmp, scan6_rsync, scan6_ldap_tcp
* Added open MySQL scan (ipv4 and ipv6): scan_mysql, scan6_mysql
* Removed double scan_nat_pmp feed
* cisco_smart_install is no longer used by shadowserver. Added scan_cisco_smart_install feed for the current version of reports, old feed is retained (see: https://www.shadowserver.org/what-we-do/network-reporting/accessible-cisco-smart-install-report/

* Cleaned up formatting
* Added comments to feeds pointing to their Shadowserver page