### PR TITLE
rm version field in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "abuseio/parser-shadowserver",
     "description": "Parser addon for handling notifications from shadowserver",
-    "version": "3.0.11",
     "keywords": ["laravel", "abuseio", "parser", "shadowserver"],
     "homepage": "http://abuse.io",
     "type": "library",


### PR DESCRIPTION
This is likely the culprit on why the new tags do not show up on [packagegist](https://packagist.org/packages/abuseio/parser-shadowserver), preventing composer from updating the parser.

```sh
$ composer validate
- The version field is present, it is recommended to leave it out if the package is published on Packagist.
```

Please tag the commit with a new version when this MR gets merged :)