### PR TITLE
Add new feeds, remove misspelled or unused filters

### DIFF
--- a/config/Shadowserver.php
+++ b/config/Shadowserver.php
@@ -733,6 +733,7 @@ return [
             ],
         ],
 
+        //https://www.shadowserver.org/what-we-do/network-reporting/compromised-website-report/
         'compromised_website' => [
             'class'     => 'COMPROMISED_WEBSITE',
             'type'      => 'ABUSE',
@@ -752,6 +753,28 @@ return [
                 'city',
             ],
         ],
+
+        //https://www.shadowserver.org/what-we-do/network-reporting/compromised-website-report/
+        'compromised_website6' => [
+            'class'     => 'COMPROMISED_WEBSITE',
+            'type'      => 'ABUSE',
+            'enabled'   => true,
+            'fields'    => [
+                'ip',
+                'timestamp',
+                'http_host',
+                'category',
+                'tag',
+                'redirect_target',
+            ],
+            'filters'   => [
+                'asn',
+                'geo',
+                'region',
+                'city',
+            ],
+        ],
+    
 
         'cwsandbox_url' => [
             'class'     => 'MALWARE_INFECTION',
@@ -1633,6 +1656,24 @@ return [
                 'city',
             ],
         ],
+
+        //https://www.shadowserver.org/what-we-do/network-reporting/netcore-netis-router-vulnerability-scan-report/
+        'scan_netis_router' => [
+            'class'     => 'NETCORE_NETIS_ROUTER_VULNERABILITY_SCAN_REPORT',
+            'type'      => 'INFO',
+            'enabled'   =>  true,
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'port',
+            ],
+            'filters'   =>[
+                'asn',
+                'geo',
+                'region',
+                'city',
+            ],
+        ],
     
         //https://www.shadowserver.org/what-we-do/network-reporting/open-db2-discovery-service-report/
         'scan_db2' => [
@@ -1717,6 +1758,28 @@ return [
     
         //https://www.shadowserver.org/what-we-do/network-reporting/open-ipp-report/
         'scan_ipp' => [
+            'class'     => 'OPEN_IPP',
+            'type'      => 'INFO',
+            'enabled'   => true,
+            'fields'    => [
+                'ip',
+                'timestamp',
+                'protocol',
+                'port',
+            ],
+            'filters'   => [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+                'sic',
+                'response',
+            ],
+        ],
+
+        //https://www.shadowserver.org/what-we-do/network-reporting/open-ipp-report/
+        'scan6_ipp' => [
             'class'     => 'OPEN_IPP',
             'type'      => 'INFO',
             'enabled'   => true,
@@ -2452,6 +2515,131 @@ return [
             ],
         ],
 
+        //https://www.shadowserver.org/what-we-do/network-reporting/accessible-kubernetes-api-server-report/
+        'scan_kubernetes' => [
+            'class'     => 'ACCESSIBLE_KUBERNETES',
+            'type'      => 'INFO',
+            'enabled'   =>  true,
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        //https://www.shadowserver.org/what-we-do/network-reporting/accessible-ms-rpc-service-report/
+        'scan_msrpc' => [
+            'class'     => 'ACCESSIBLE_MSRPC',
+            'type'      => 'INFO',
+            'enabled'   =>  true,
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        //https://www.shadowserver.org/what-we-do/network-reporting/accessible-imap-report/
+        'scan_imap' => [
+            'class'     => 'ACCESSIBLE_IMAP',
+            'type'      => 'INFO',
+            'enabled'   =>  true,
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+    //https://www.shadowserver.org/what-we-do/network-reporting/accessible-imap-report/
+        'scan6_imap' => [
+            'class'     => 'ACCESSIBLE_IMAP',
+            'type'      => 'INFO',
+            'enabled'   =>  true,
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        //https://www.shadowserver.org/what-we-do/network-reporting/accessible-pop3-report/
+        'scan_pop3' => [
+            'class'     => 'ACCESSIBLE_POP3',
+            'type'      => 'INFO',
+            'enabled'   =>  true,
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
+
+        //https://www.shadowserver.org/what-we-do/network-reporting/accessible-pop3-report/
+        'scan6_pop3' => [
+            'class'     => 'ACCESSIBLE_POP3',
+            'type'      => 'INFO',
+            'enabled'   =>  true,
+            'fields'    =>  [
+                'timestamp',
+                'ip',
+                'hostname',
+                'protocol',
+                'port',
+            ],
+            'filters'   =>  [
+                'asn',
+                'geo',
+                'region',
+                'city',
+                'naics',
+            ],
+        ],
 
     ],
 ];

--- a/config/Shadowserver.php
+++ b/config/Shadowserver.php
@@ -59,7 +59,6 @@ return [
                  'region',
                  'city',
                  'naics',
-                 'sic',
              ],
          ],
 
@@ -73,7 +72,7 @@ return [
                  'timestamp',
                  'port',
                  'server_type',
-                 'clisterid',
+                 'clusterid',
                  'total_disk',
                  'livenodes',
                  'namenodeaddress',
@@ -85,7 +84,6 @@ return [
                  'region',
                  'city',
                  'naics',
-                 'sic',
              ],
          ],
 
@@ -128,7 +126,6 @@ return [
                  'region',
                  'city',
                  'naics',
-                 'sic',
              ],
          ],
 
@@ -148,7 +145,6 @@ return [
                  'region',
                  'city',
                  'naics',
-                 'sic',
              ],
          ],
 
@@ -168,7 +164,6 @@ return [
                  'region',
                  'city',
                  'naics',
-                 'sic',
              ],
          ],
 
@@ -188,7 +183,6 @@ return [
                  'region',
                  'city',
                  'naics',
-                 'sic',
              ],
          ],
 
@@ -209,7 +203,6 @@ return [
                  'region',
                  'city',
                  'naics',
-                 'sic',
              ],
          ],
 
@@ -230,7 +223,6 @@ return [
                  'region',
                  'city',
                  'naics',
-                 'sic',
              ],
          ],
 
@@ -251,7 +243,6 @@ return [
                  'region',
                  'city',
                  'naics',
-                 'sic',
              ],
          ],
     
@@ -272,7 +263,6 @@ return [
                  'region',
                  'city',
                  'naics',
-                 'sic',
              ],
          ],
  
@@ -332,7 +322,6 @@ return [
                 'region',
                 'city',
                 'naics',
-                'sic',
             ],
         ],
 
@@ -352,7 +341,6 @@ return [
                 'region',
                 'city',
                 'naics',
-                'sic',
                 'sector',
             ],
         ],
@@ -373,7 +361,6 @@ return [
                 'region',
                 'city',
                 'naics',
-                'sic',
                 'sector',
             ],
         ],
@@ -395,7 +382,6 @@ return [
                 'region',
                 'city',
                 'naics',
-                'sic',
             ],
         ],
 
@@ -417,7 +403,6 @@ return [
                 'region',
                 'city',
                 'naics',
-                'sic',
             ],
         ],
 
@@ -442,7 +427,6 @@ return [
                 'region',
                 'city',
                 'naics',
-                'sic',
             ],
         ],
 
@@ -701,7 +685,7 @@ return [
                 'port',
                 'hostname',
                 'packets',
-                'size',
+                'response_size',
             ],
             'filters'   => [
                 'asn',
@@ -723,7 +707,7 @@ return [
                 'port',
                 'hostname',
                 'packets',
-                'size',
+                'response_size',
             ],
             'filters'   => [
                 'asn',
@@ -998,6 +982,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-ssdp-report/
         'scan_ssdp' => [
             'class'     => 'OPEN_SSDP_SERVER',
             'type'      => 'INFO',
@@ -1028,7 +1013,7 @@ return [
                 'timestamp',
                 'protocol',
                 'port',
-                'size',
+                'response_size',
             ],
             'filters'   => [
                 'asn',
@@ -1135,6 +1120,7 @@ return [
             ],
         ],
 
+        // https://www.shadowserver.org/what-we-do/network-reporting/open-memcached-report/
         'scan_memcached' => [
             'class'     => 'OPEN_MEMCACHED_SERVER',
             'type'      => 'INFO',
@@ -1773,8 +1759,6 @@ return [
                 'region',
                 'city',
                 'naics',
-                'sic',
-                'response',
             ],
         ],
 
@@ -1795,8 +1779,6 @@ return [
                 'region',
                 'city',
                 'naics',
-                'sic',
-                'response',
             ],
         ],
     
@@ -2328,7 +2310,6 @@ return [
                 'ip',
                 'hostname',
                 'port',
-                'version',
             ],
             'filters'   =>  [
                 'asn',
@@ -2349,7 +2330,6 @@ return [
                 'ip',
                 'hostname',
                 'port',
-                'version',
             ],
             'filters'   =>  [
                 'asn',
@@ -2608,7 +2588,6 @@ return [
                 'timestamp',
                 'ip',
                 'hostname',
-                'protocol',
                 'port',
             ],
             'filters'   =>  [
@@ -2629,7 +2608,6 @@ return [
                 'timestamp',
                 'ip',
                 'hostname',
-                'protocol',
                 'port',
             ],
             'filters'   =>  [


### PR DESCRIPTION
This PR includes the addition of a number of new feeds as well as the removal of filters no longer used by Shadowserver in its reports. This should also prevent exceptions from occurring when the parser is looking for things in the csv that do not exist (as these non existent things have been removed from the feeds).

No new classifications for the new feeds have been added as an update to classifications (without new feeds) is still pending before these new ones can also be added.
https://github.com/AbuseIO/AbuseIO/pull/409

I think there will be breakage should the parser be updated before the classifications have been added.
Version tag should be updated